### PR TITLE
Disable Google Image Safe Search

### DIFF
--- a/scripts/google-images.coffee
+++ b/scripts/google-images.coffee
@@ -26,7 +26,7 @@ module.exports = (robot) ->
 
 imageMe = (msg, query, cb) ->
   msg.http('http://ajax.googleapis.com/ajax/services/search/images')
-    .query(v: "1.0", rsz: '8', q: query, safe: 'active')
+    .query(v: "1.0", rsz: '8', q: query, safe: 'off')
     .get() (err, res, body) ->
       images = JSON.parse(body)
       images = images.responseData.results


### PR DESCRIPTION
A continuous desire to remove google safe search has finally been alleviated.  This request has the appropriate changes to disable such in the google images coffee script.
